### PR TITLE
feat: acot-a11y compatible element2selector implementation and tests

### DIFF
--- a/hstest/environment/element.ts
+++ b/hstest/environment/element.ts
@@ -1,7 +1,6 @@
 import {ElementHandle, Page} from 'puppeteer';
-import { ElementHandle as ElementHandleCore} from "puppeteer-core";
 import EventHandler from "../handler/eventHandler.js";
-import {element2selector} from "puppeteer-element2selector";
+import {element2selector} from "../utils/element2selector.js";
 import WrongAnswer from "../exception/outcome/WrongAnswer.js";
 
 export default class Element {
@@ -20,7 +19,7 @@ export default class Element {
 
     static async new(elementHandle: ElementHandle, parent: Element | null, page: Page) {
         try {
-            const selector = await element2selector(elementHandle as unknown as ElementHandleCore);
+            const selector = await element2selector(elementHandle as ElementHandle);
             return new Element(elementHandle, selector, parent, page);
         } catch {
             throw new WrongAnswer('Make sure your elements don\'t have duplicated id attribute');
@@ -102,7 +101,11 @@ export default class Element {
 
     async findByClassName(className: string) {
         const classSelector = `.${className}`;
-        return await this.findBySelector(classSelector);
+        const element = await this.select(classSelector);
+        if (element === null) {
+            return element;
+        }
+        return new Element(element as ElementHandle, classSelector, this, this.page);
     }
 
     async findBySelector(selector: string) {

--- a/hstest/utils/element2selector.ts
+++ b/hstest/utils/element2selector.ts
@@ -1,0 +1,88 @@
+import type { ElementHandle } from 'puppeteer';
+
+/**
+ * Generate a CSS selector for the given element.
+ * Logic is based on acot-a11y/puppeteer-element2selector.
+ */
+export const element2selector = async (element: ElementHandle): Promise<string> => {
+  if (!element) throw new Error('Invalid element');
+
+  return await element.evaluate((el: Element) => {
+    if (!el || el.nodeType !== Node.ELEMENT_NODE) {
+      throw new Error('Invalid element');
+    }
+
+    function escapeClass(cls: string) {
+      return cls.replace(/([.!#$%&'*+\-/:;<=>?@[\]^`{|}~])/g, '$1');
+    }
+
+    function getSelector(element: Element): string {
+      // id (if unique)
+      if (element.id) {
+        const elementsWithId = document.querySelectorAll('#' + CSS.escape(element.id));
+        if (elementsWithId.length === 1) {
+          return `#${CSS.escape(element.id)}`;
+        } else if (elementsWithId.length > 1) {
+          throw new Error('Make sure your elements don\'t have duplicated id attribute');
+        }
+      }
+      let selector = element.tagName.toLowerCase();
+      // classes
+      if (element.classList.length > 0) {
+        selector += Array.from(element.classList)
+          .map(cls => '.' + escapeClass(cls))
+          .join('');
+      }
+      // nth-of-type (only if there are siblings with the same tag and classes/id)
+      if (
+        element.parentElement &&
+        element.tagName.toLowerCase() !== 'html' &&
+        element.tagName.toLowerCase() !== 'body'
+      ) {
+        const parent = element.parentElement;
+        // Collect selector for comparison
+        let baseSelector = element.tagName.toLowerCase();
+        if (element.classList.length > 0) {
+          baseSelector += Array.from(element.classList)
+            .map(cls => '.' + escapeClass(cls))
+            .join('');
+        }
+        if (element.id) {
+          baseSelector += `#${CSS.escape(element.id)}`;
+        }
+        const siblings = Array.from(parent.children).filter((el) => {
+          const sib = el as Element;
+          let sibSelector = sib.tagName.toLowerCase();  
+          if (sib.classList.length > 0) {
+            sibSelector += Array.from(sib.classList)
+              .map(cls => '.' + escapeClass(cls))
+              .join('');
+          }
+          if (sib.id) {
+            sibSelector += `#${CSS.escape(sib.id)}`;
+          }
+          return sibSelector === baseSelector;
+        });
+        if (siblings.length > 1) {
+          const index = siblings.indexOf(element);
+          if (index > 0) {
+            selector += `:nth-of-type(${index + 1})`;
+          }
+        }
+      }
+      return selector;
+    }
+
+    const path: string[] = [];
+    let current: Element | null = el;
+    while (current && current.nodeType === Node.ELEMENT_NODE) {
+      const selector = getSelector(current);
+      path.unshift(selector);
+      // If unique id is found, path is built, and we can finish
+      if (selector.startsWith('#')) break;
+      current = current.parentElement;
+    }
+    return path.join(' > ');
+
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,32 @@
 {
   "name": "hs-test-web-ts",
-  "version": "4.1.1",
+  "version": "4.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hs-test-web-ts",
-      "version": "4.1.1",
+      "version": "4.1.3",
       "dependencies": {
+        "@medv/finder": "^4.0.2",
         "@types/callsite": "^1.0.34",
         "callsite": "^1.0.0",
-        "puppeteer": "24.6.1",
-        "puppeteer-element2selector": "0.0.3"
+        "puppeteer": "24.6.1"
       },
       "devDependencies": {
         "@babel/core": ">=7.26.0",
         "@babel/preset-env": ">=7.26.0",
         "@babel/preset-react": ">=7.26.3",
+        "@types/chai": "^5.2.2",
+        "@types/chai-as-promised": "^8.0.2",
+        "@types/mocha": "^10.0.10",
         "@types/webpack": "5.28.5",
         "@types/webpack-dev-server": "4.7.2",
         "@typescript-eslint/eslint-plugin": "^8.29.1",
         "@typescript-eslint/parser": "^8.29.1",
         "babel-loader": "^9.2.1",
         "chai": "^5.2.0",
+        "chai-as-promised": "^8.0.1",
         "css-loader": "^7.1.2",
         "eslint": "^8.57.1",
         "file-loader": ">=6.0.0",
@@ -1993,9 +1997,9 @@
       "license": "MIT"
     },
     "node_modules/@medv/finder": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@medv/finder/-/finder-2.1.0.tgz",
-      "integrity": "sha512-Egrg5XO4kLol24b1Kv50HDfi5hW0yQ6aWSsO0Hea1eJ4rogKElIN0M86FdVnGF4XIGYyA7QWx0MgbOzVPA0qkA=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@medv/finder/-/finder-4.0.2.tgz",
+      "integrity": "sha512-RraNY9SCcx4KZV0Dh6BEW6XEW2swkqYca74pkFFRw6hHItSHiy+O/xMnpbofjYbzXj0tSpBGthUF1hHTsr3vIQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2171,6 +2175,24 @@
       "resolved": "https://registry.npmjs.org/@types/callsite/-/callsite-1.0.34.tgz",
       "integrity": "sha512-eglitkkbqiQiijtKsUvOcQm+E6qLMPcggjDJXeqNBnLxdzffRGop2+2QDN/8pHh396/jN5cmIwweNKUqKJ50mQ=="
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-8.0.2.tgz",
+      "integrity": "sha512-meQ1wDr1K5KRCSvG2lX7n7/5wf70BeptTKst0axGvnN6zqaVpRqegoIbugiAPSqOW9K9aL8gDVrm7a2LXOtn2Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2191,6 +2213,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -2273,6 +2301,12 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.7.23",
@@ -3775,6 +3809,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.1.tgz",
+      "integrity": "sha512-OIEJtOL8xxJSH8JJWbIoRjybbzR52iFuDHuF8eb+nTPD6tgXLjRqsgnUGqQfFODxYvq5QdirT0pN9dZ0+Gz6rA==",
+      "dev": true,
+      "dependencies": {
+        "check-error": "^2.0.0"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 6"
       }
     },
     "node_modules/check-error": {
@@ -7254,17 +7300,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/puppeteer-element2selector": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-element2selector/-/puppeteer-element2selector-0.0.3.tgz",
-      "integrity": "sha512-HgjLYDY3Ni67nDYEEE4hqJIoVEjwFeTXCO92tkJjYJKLbGNgM5/Zsa6ubaeYQ2fzGx10xZoejdUxlQnGuTbQ0g==",
-      "dependencies": {
-        "@medv/finder": "^2.0.0"
-      },
-      "peerDependencies": {
-        "puppeteer-core": ">= 2.1.0"
-      }
-    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -10503,9 +10538,9 @@
       "dev": true
     },
     "@medv/finder": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@medv/finder/-/finder-2.1.0.tgz",
-      "integrity": "sha512-Egrg5XO4kLol24b1Kv50HDfi5hW0yQ6aWSsO0Hea1eJ4rogKElIN0M86FdVnGF4XIGYyA7QWx0MgbOzVPA0qkA=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@medv/finder/-/finder-4.0.2.tgz",
+      "integrity": "sha512-RraNY9SCcx4KZV0Dh6BEW6XEW2swkqYca74pkFFRw6hHItSHiy+O/xMnpbofjYbzXj0tSpBGthUF1hHTsr3vIQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -10643,6 +10678,24 @@
       "resolved": "https://registry.npmjs.org/@types/callsite/-/callsite-1.0.34.tgz",
       "integrity": "sha512-eglitkkbqiQiijtKsUvOcQm+E6qLMPcggjDJXeqNBnLxdzffRGop2+2QDN/8pHh396/jN5cmIwweNKUqKJ50mQ=="
     },
+    "@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "requires": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "@types/chai-as-promised": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-8.0.2.tgz",
+      "integrity": "sha512-meQ1wDr1K5KRCSvG2lX7n7/5wf70BeptTKst0axGvnN6zqaVpRqegoIbugiAPSqOW9K9aL8gDVrm7a2LXOtn2Q==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -10661,6 +10714,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "9.6.1",
@@ -10737,6 +10796,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "dev": true
     },
     "@types/node": {
@@ -11768,6 +11833,15 @@
         "deep-eql": "^5.0.1",
         "loupe": "^3.1.0",
         "pathval": "^2.0.0"
+      }
+    },
+    "chai-as-promised": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.1.tgz",
+      "integrity": "sha512-OIEJtOL8xxJSH8JJWbIoRjybbzR52iFuDHuF8eb+nTPD6tgXLjRqsgnUGqQfFODxYvq5QdirT0pN9dZ0+Gz6rA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^2.0.0"
       }
     },
     "check-error": {
@@ -14218,14 +14292,6 @@
         "devtools-protocol": "0.0.1425554",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.1"
-      }
-    },
-    "puppeteer-element2selector": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-element2selector/-/puppeteer-element2selector-0.0.3.tgz",
-      "integrity": "sha512-HgjLYDY3Ni67nDYEEE4hqJIoVEjwFeTXCO92tkJjYJKLbGNgM5/Zsa6ubaeYQ2fzGx10xZoejdUxlQnGuTbQ0g==",
-      "requires": {
-        "@medv/finder": "^2.0.0"
       }
     },
     "qs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hs-test-web-ts",
-  "version": "4.2.0",
+  "version": "4.1.3",
   "description": "Hyperskill Testing Library on TypeScript",
   "main": "dist/hstest/index.js",
   "scripts": {
@@ -13,21 +13,25 @@
   "keywords": [],
   "author": "Vladimir Turov & Ainur Gimadeev",
   "dependencies": {
+    "@medv/finder": "^4.0.2",
     "@types/callsite": "^1.0.34",
     "callsite": "^1.0.0",
-    "puppeteer": "24.6.1",
-    "puppeteer-element2selector": "0.0.3"
+    "puppeteer": "24.6.1"
   },
   "devDependencies": {
     "@babel/core": ">=7.26.0",
     "@babel/preset-env": ">=7.26.0",
     "@babel/preset-react": ">=7.26.3",
+    "@types/chai": "^5.2.2",
+    "@types/chai-as-promised": "^8.0.2",
+    "@types/mocha": "^10.0.10",
     "@types/webpack": "5.28.5",
     "@types/webpack-dev-server": "4.7.2",
     "@typescript-eslint/eslint-plugin": "^8.29.1",
     "@typescript-eslint/parser": "^8.29.1",
     "babel-loader": "^9.2.1",
     "chai": "^5.2.0",
+    "chai-as-promised": "^8.0.1",
     "css-loader": "^7.1.2",
     "eslint": "^8.57.1",
     "file-loader": ">=6.0.0",

--- a/tests/vanilla/utils/element2selector.test.mjs
+++ b/tests/vanilla/utils/element2selector.test.mjs
@@ -1,0 +1,117 @@
+import puppeteer from 'puppeteer';
+import { element2selector } from '../../../dist/hstest/utils/element2selector.js';
+import { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import * as chai from 'chai';
+
+chai.use(chaiAsPromised);
+
+describe('element2selector (JS version, full coverage)', function () {
+    let browser;
+    let page;
+
+    before(async () => {
+        browser = await puppeteer.launch({ headless: true });
+        page = await browser.newPage();
+    });
+
+    after(async () => {
+        await browser.close();
+    });
+
+    beforeEach(async () => {
+        await page.setContent(`
+      <html>
+        <body>
+          <div id="unique-id">A</div>
+
+          <div id="duplicated">B1</div>
+          <div id="duplicated">B2</div>
+
+          <div class="container">
+            <span>Item 1</span>
+            <span>Item 2</span>
+          </div>
+
+          <ul>
+            <li>One</li>
+            <li>Two</li>
+            <li>Three</li>
+          </ul>
+
+          <div>
+            <section>
+              <article>
+                <p>Deep</p>
+              </article>
+            </section>
+          </div>
+
+          <div data-test="no-id">
+            <span class="no-id">Child</span>
+          </div>
+
+          <svg>
+            <circle cx="50" cy="50" r="40" stroke="black" fill="red" />
+          </svg>
+        </body>
+      </html>
+    `);
+    });
+
+    it('should return #id if ID is unique', async () => {
+        const handle = await page.$('#unique-id');
+        const selector = await element2selector(handle);
+        expect(selector).to.equal('#unique-id');
+    });
+
+    it('should throw error for duplicated id', async () => {
+        const handles = await page.$$('[id="duplicated"]');
+        await expect(element2selector(handles[0])).to.be.rejectedWith(/duplicated id/i);
+    });
+
+    it('should return nth-of-type for siblings with same tag', async () => {
+        const handles = await page.$$('.container span');
+        const selector = await element2selector(handles[1]);
+        expect(selector).to.equal('html > body > div.container > span:nth-of-type(2)');
+    });
+
+    it('should generate correct selector for list items', async () => {
+        const handles = await page.$$('ul li');
+        const selector = await element2selector(handles[2]);
+        expect(selector).to.equal('html > body > ul > li:nth-of-type(3)');
+    });
+
+    it('should generate full path for deeply nested element', async () => {
+        const handle = await page.$('p');
+        const selector = await element2selector(handle);
+        expect(selector).to.match(/^html > body > div > section > article > p$/);
+    });
+
+    it('should work with elements without id or class', async () => {
+        const handle = await page.$('[data-test="no-id"] .no-id');
+        const selector = await element2selector(handle);
+        expect(selector).to.include('span');
+    });
+
+    it('should throw on null element', async () => {
+        await expect(element2selector(null)).to.be.rejectedWith(/Invalid element/);
+    });
+
+    it('should handle dynamically added DOM elements', async () => {
+        await page.evaluate(() => {
+            const div = document.createElement('div');
+            div.className = 'dynamic';
+            document.body.appendChild(div);
+        });
+        const handle = await page.$('.dynamic');
+        const selector = await element2selector(handle);
+        expect(selector).to.match(/div.dynamic$/);
+    });
+
+    it('should support SVG elements', async () => {
+        const handle = await page.$('circle');
+        const selector = await element2selector(handle);
+        expect(selector).to.match(/svg > circle/);
+    });
+});


### PR DESCRIPTION
- Rewrite element2selector to match acot-a11y/puppeteer-element2selector logic
- Add proper :nth-of-type only for siblings with same tag/class/id
- Improve comments and function docs
- Add/expand test suite for full edge case coverage

Task: [#HSPC-187](https://vyahhi.myjetbrains.com/youtrack/issue/HSPC-187)
**Dependencies**
- !

**Reviewers**
- [ ] @meanmail 

**Description**
